### PR TITLE
adds ZTEST for csp_rdp_queue_tx_size

### DIFF
--- a/src/rdp_queue.c
+++ b/src/rdp_queue.c
@@ -7,6 +7,8 @@
 #include <zephyr/ztest.h>
 #include <csp/csp.h>
 
+#define QUEUE_SIZE_MAX (CSP_RDP_MAX_WINDOW * 2)
+
 void csp_rdp_queue_init(void);
 int csp_rdp_queue_tx_size(void);
 int csp_rdp_queue_rx_size(void);
@@ -44,6 +46,129 @@ ZTEST(rdp_queue, test_rdp_queue_add_and_get)
 	zassert_not_null(p2);
 	printf("%p %p\n", p1, p2);
 	zassert_equal_ptr(p1, p2);
+}
+
+/* test when queue size is 1 */
+ZTEST(rdp_queue, test_rdp_queue_one)
+{
+	csp_packet_t *packet;
+
+	/* create queue */
+	csp_rdp_queue_init();
+	zassert_equal(0, csp_rdp_queue_tx_size());
+
+	/* create packet */
+	csp_buffer_init();
+	packet = csp_buffer_get(0);
+	zassert_not_null(packet);
+
+	/* add packets to queue */
+	csp_rdp_queue_tx_add(NULL, packet);
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(1, size, "queue size is not 1. queue size is %d.", size);
+}
+
+/* enqueue and dequeue test  */
+ZTEST(rdp_queue, test_rdp_queue_enqueue_dequeue)
+{
+	csp_packet_t *pEnqueuePacket;
+	csp_packet_t *pDequeuePacket;
+
+	/* create queue */
+	csp_rdp_queue_init();
+	zassert_equal(0, csp_rdp_queue_tx_size());
+
+	/* create packet */
+	csp_buffer_init();
+	pEnqueuePacket = csp_buffer_get(0);
+	zassert_not_null(pEnqueuePacket);
+
+	/* enqueue */
+	csp_rdp_queue_tx_add(NULL, pEnqueuePacket);
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(1, size, "queue size is not 1. queue size is %d.", size);
+
+	/* dequeue */
+	pDequeuePacket = csp_rdp_queue_tx_get(NULL);
+	zassert_not_null(pDequeuePacket);
+	size = csp_rdp_queue_tx_size();
+	zassert_equal(0, size, "queue size is not 0. queue size is %d.", size);
+	zassert_equal_ptr(pEnqueuePacket, pDequeuePacket);
+}
+
+/* test when queue size is MAX */
+ZTEST(rdp_queue, test_rdp_queue_MAX)
+{
+	csp_packet_t *packet;
+
+	/* create queue */
+	csp_rdp_queue_init();
+	zassert_equal(0, csp_rdp_queue_tx_size());
+
+	/* enqueue until queue is filled */
+	csp_buffer_init();
+	for (int i = 0; i < QUEUE_SIZE_MAX; i++) {
+		/* create packet */
+		packet = csp_buffer_get(0);
+		zassert_not_null(packet);
+
+		/* enqueue */
+		csp_rdp_queue_tx_add(NULL, packet);
+		zassert_equal((i+1), csp_rdp_queue_tx_size());
+	}
+
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+
+	/* can not add when queue size is MAX */
+	packet = csp_buffer_get(0);
+	zassert_not_null(packet);
+	csp_rdp_queue_tx_add(NULL, packet);
+
+	size = csp_rdp_queue_tx_size();
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+}
+
+/* queue up to Max, then dequeue all */
+ZTEST(rdp_queue, test_rdp_enqueue_MAX_and_dequeue)
+{
+	csp_packet_t *packet;
+
+	/* create queue */
+	csp_rdp_queue_init();
+	zassert_equal(0, csp_rdp_queue_tx_size());
+
+	/* enqueue until queue is filled */
+	csp_buffer_init();
+	for (int i = 0; i < QUEUE_SIZE_MAX; i++) {
+		/* create packet */
+		packet = csp_buffer_get(0);
+		zassert_not_null(packet);
+
+		/* enqueue */
+		csp_rdp_queue_tx_add(NULL, packet);
+		zassert_equal((i+1), csp_rdp_queue_tx_size());
+	}
+
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+
+	/* dequeue all */
+	for (int i = QUEUE_SIZE_MAX; i > 0; i--) {
+		/* dequeue packet */
+		packet = csp_rdp_queue_tx_get(NULL);
+		zassert_not_null(packet);
+		zassert_equal((i-1), csp_rdp_queue_tx_size());
+	}
+
+	size = csp_rdp_queue_tx_size();
+	zassert_equal(0, size, "queue size is not 0. queue size is %d.", size);
+
+	/* can not dequeue when queue size is 0 */
+	packet = csp_rdp_queue_tx_get(NULL);
+	zassert_is_null(packet);
+	size = csp_rdp_queue_tx_size();
+	zassert_equal(0, size, "queue size is not 0. queue size is %d.", size);
 }
 
 ZTEST_SUITE(rdp_queue, NULL, NULL, NULL, NULL, NULL);

--- a/src/rdp_queue.c
+++ b/src/rdp_queue.c
@@ -71,8 +71,8 @@ ZTEST(rdp_queue, test_rdp_queue_one)
 /* enqueue and dequeue test  */
 ZTEST(rdp_queue, test_rdp_queue_enqueue_dequeue)
 {
-	csp_packet_t *pEnqueuePacket;
-	csp_packet_t *pDequeuePacket;
+	csp_packet_t *enqueue_packet;
+	csp_packet_t *dequeue_packet;
 
 	/* create queue */
 	csp_rdp_queue_init();
@@ -80,24 +80,24 @@ ZTEST(rdp_queue, test_rdp_queue_enqueue_dequeue)
 
 	/* create packet */
 	csp_buffer_init();
-	pEnqueuePacket = csp_buffer_get(0);
-	zassert_not_null(pEnqueuePacket);
+	enqueue_packet = csp_buffer_get(0);
+	zassert_not_null(enqueue_packet);
 
 	/* enqueue */
-	csp_rdp_queue_tx_add(NULL, pEnqueuePacket);
+	csp_rdp_queue_tx_add(NULL, enqueue_packet);
 	int size = csp_rdp_queue_tx_size();
 	zassert_equal(1, size, "queue size is not 1. queue size is %d.", size);
 
 	/* dequeue */
-	pDequeuePacket = csp_rdp_queue_tx_get(NULL);
-	zassert_not_null(pDequeuePacket);
+	dequeue_packet = csp_rdp_queue_tx_get(NULL);
+	zassert_not_null(dequeue_packet);
 	size = csp_rdp_queue_tx_size();
 	zassert_equal(0, size, "queue size is not 0. queue size is %d.", size);
-	zassert_equal_ptr(pEnqueuePacket, pDequeuePacket);
+	zassert_equal_ptr(enqueue_packet, dequeue_packet);
 }
 
-/* test when queue size is MAX */
-ZTEST(rdp_queue, test_rdp_queue_MAX)
+/* test when queue size is max */
+ZTEST(rdp_queue, test_rdp_queue_max)
 {
 	csp_packet_t *packet;
 
@@ -118,19 +118,19 @@ ZTEST(rdp_queue, test_rdp_queue_MAX)
 	}
 
 	int size = csp_rdp_queue_tx_size();
-	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not max. queue size is %d.", size);
 
-	/* can not add when queue size is MAX */
+	/* can not add when queue size is max */
 	packet = csp_buffer_get(0);
 	zassert_not_null(packet);
 	csp_rdp_queue_tx_add(NULL, packet);
 
 	size = csp_rdp_queue_tx_size();
-	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not max. queue size is %d.", size);
 }
 
-/* queue up to Max, then dequeue all */
-ZTEST(rdp_queue, test_rdp_enqueue_MAX_and_dequeue)
+/* queue up to max, then dequeue all */
+ZTEST(rdp_queue, test_rdp_enqueue_max_and_dequeue)
 {
 	csp_packet_t *packet;
 
@@ -151,7 +151,7 @@ ZTEST(rdp_queue, test_rdp_enqueue_MAX_and_dequeue)
 	}
 
 	int size = csp_rdp_queue_tx_size();
-	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not MAX. queue size is %d.", size);
+	zassert_equal(QUEUE_SIZE_MAX, size, "queue size is not max. queue size is %d.", size);
 
 	/* dequeue all */
 	for (int i = QUEUE_SIZE_MAX; i > 0; i--) {

--- a/src/rdp_queue.c
+++ b/src/rdp_queue.c
@@ -171,4 +171,59 @@ ZTEST(rdp_queue, test_rdp_enqueue_max_and_dequeue)
 	zassert_equal(0, size, "queue size is not 0. queue size is %d.", size);
 }
 
+/* queue flush test */
+ZTEST(rdp_queue, test_rdp_queue_flush)
+{
+	csp_conn_t *conn;
+	csp_packet_t *packet_tx;
+	csp_packet_t *packet_rx;
+
+	/* create connection */
+	csp_conn_init();
+	conn = csp_conn_allocate(CONN_CLIENT);
+
+	/* create queue */
+	csp_rdp_queue_init();
+	zassert_equal(0, csp_rdp_queue_tx_size());
+	zassert_equal(0, csp_rdp_queue_rx_size());
+
+	/* create packet */
+	csp_buffer_init();
+	packet_tx = csp_buffer_get(0);
+	zassert_not_null(packet_tx);
+	packet_rx = csp_buffer_get(0);
+	zassert_not_null(packet_rx);
+
+	/* enqueue */
+	csp_rdp_queue_tx_add(NULL, packet_tx);
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(1, size, "tx_queue size is not 1. tx_queue size is %d.", size);
+	csp_rdp_queue_rx_add(NULL, packet_rx);
+	size = csp_rdp_queue_rx_size();
+	zassert_equal(1, size, "rx_queue size is not 1. rx_queue size is %d.", size);
+
+	/* queue flush */
+	csp_rdp_queue_flush(conn);
+	size = csp_rdp_queue_tx_size();
+	zassert_equal(0, size, "tx_queue size is not 0. tx_queue size is %d.", size);
+	size = csp_rdp_queue_rx_size();
+	zassert_equal(0, size, "rx_queue size is not 0. rx_queue size is %d.", size);
+}
+
+/* uninitialized queue test */
+ZTEST(rdp_queue, test_queue_no_init)
+{
+	csp_packet_t *packet;
+
+	/* create packet */
+	csp_buffer_init();
+	packet = csp_buffer_get(0);
+	zassert_not_null(packet);
+
+	/* enqueue */
+	csp_rdp_queue_tx_add(NULL, packet);
+	int size = csp_rdp_queue_tx_size();
+	zassert_equal(1, size, "queue size is not 1. queue size is %d.", size);
+}
+
 ZTEST_SUITE(rdp_queue, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This pull request adds ZTEST for csp_rdp_queue_tx_size() function.
Test cases to be added are as follows:
・test_rdp_queue_emtpy
・test_rdp_queue_add_and_get
・test_rdp_queue_one
・test_rdp_queue_enqueue_dequeue
・test_rdp_queue_max
・test_rdp_enqueue_max_and_dequeue
・test_rdp_queue_flush
・test_queue_no_init